### PR TITLE
export RadarMessage.Batch and add interface tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
-var Request = require('./message_request.js'),
-    Response = require('./message_response.js'),
+var Request = require('./message_request'),
+    Response = require('./message_response'),
+    Batch = require('./batch_message'),
     RadarMessage = function() {};
 
+RadarMessage.Batch = Batch;
 RadarMessage.Request = Request;
 RadarMessage.Response = Response;
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "chai-interface": "^2.0.2",
     "mocha": "*"
   },
   "scripts": {

--- a/test/interface.test.js
+++ b/test/interface.test.js
@@ -1,0 +1,30 @@
+/* globals describe, it */
+var chai = require('chai')
+var expect = chai.expect
+chai.use(require('chai-interface'))
+
+var RadarMessage = require('../.')
+
+describe('RadarMessage', function () {
+  it('should have interface', function () {
+    expect(RadarMessage).to.have.interface({
+      Request: Function,
+      Response: Function,
+      Batch: Function
+    })
+  })
+
+  describe('.Request', function () {
+    it('should have interface', function () {
+      expect(RadarMessage.Request).to.have.interface({
+        buildGet: Function,
+        buildPublish: Function,
+        buildPush: Function,
+        buildNameSync: Function,
+        buildSet: Function,
+        buildSync: Function,
+        buildUnsubscribe: Function
+      })
+    })
+  })
+})


### PR DESCRIPTION
exposes Batch constructor as RadarMessage.Batch
# Required
- [ ] :+1: from @zendesk/radar
# Risks
- None
