### PR TITLE
[RADAR-689] Prevents null error when options is null

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### v1.3.1
+* [PR #12](https://github.com/zendesk/radar_message/pull/12) - Fixes an error when `options: null` is passed to presence sync
+
 ### v1.3.0
 * [PR #10](https://github.com/zendesk/radar_message/pull/10) - Updates packages and runs Travis in Node 10 & 12
 * [PR #11](https://github.com/zendesk/radar_message/pull/11) - Updates packages, adds standard and fixes offences, adds a PR template and updates to ES6 syntax

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -72,6 +72,7 @@ Request.buildUnsubscribe = function (scope, message = { op: 'unsubscribe', to: s
 // Instance methods
 
 Request.prototype.forceV2Sync = function (options = {}) {
+  options = options || {} // options is sometimes null, which would cause an exception on the next line
   options.version = 2
   this.setAttr('options', options)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar_message",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar_message",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "radar message api library",
   "main": "lib/index.js",
   "author": "Zendesk, Inc.",

--- a/test/request.unit.test.js
+++ b/test/request.unit.test.js
@@ -79,6 +79,36 @@ describe('Request', function () {
     assert.strictEqual(request.getType(), 'message')
   })
 
+  it('build a presence request', function () {
+    const request = Request.buildSync('presence:/test/ticket/1')
+
+    assert.deepStrictEqual(
+      request.getMessage(),
+      {
+        op: 'sync',
+        to: 'presence:/test/ticket/1',
+        options: {
+          version: 2
+        }
+      })
+    assert.strictEqual(request.getType(), 'presence')
+  })
+
+  it('build a presence request, with options null', function () {
+    const request = Request.buildSync('presence:/test/ticket/1', null)
+
+    assert.deepStrictEqual(
+      request.getMessage(),
+      {
+        op: 'sync',
+        to: 'presence:/test/ticket/1',
+        options: {
+          version: 2
+        }
+      })
+    assert.strictEqual(request.getType(), 'presence')
+  })
+
   it('build a subscribe request', function () {
     const request = Request.buildSubscribe('presence:/test/ticket/1')
 


### PR DESCRIPTION
### Description

In an upstream repo we sometimes pass `null` to the options when building
a presence sync, which was throwing an error. Adding some tests for that
scenario, and the fix

cc @zendesk/radar 

### References

* Jira: [RADAR-689](https://zendesk.atlassian.net/browse/RADAR-689)

### Risks

* Low : Bug fix
* Rollback: Revert
